### PR TITLE
Fix group ownership for configuration files

### DIFF
--- a/openstack-aodh.spec
+++ b/openstack-aodh.spec
@@ -261,9 +261,9 @@ exit 0
 
 %files common
 %dir %{_sysconfdir}/aodh
-%config(noreplace) %attr(-, root, ceilometer) %{_sysconfdir}/aodh/aodh.conf
-%config(noreplace) %attr(-, root, ceilometer) %{_sysconfdir}/aodh/policy.json
-%config(noreplace) %attr(-, root, ceilometer) %{_sysconfdir}/aodh/api_paste.ini
+%config(noreplace) %attr(-, root, aodh) %{_sysconfdir}/aodh/aodh.conf
+%config(noreplace) %attr(-, root, aodh) %{_sysconfdir}/aodh/policy.json
+%config(noreplace) %attr(-, root, aodh) %{_sysconfdir}/aodh/api_paste.ini
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
 %dir %{_localstatedir}/log/aodh
 %dir %{_sharedstatedir}/aodh


### PR DESCRIPTION
Do not use 'ceilometer' group (that is not managed by this package) but
'aodh'.

Otherwise, /etc/aodh/* files will be owned by root:root and aodh
services will never start.